### PR TITLE
feat: Word Builder

### DIFF
--- a/src/app/alphabet-grid/alphabet-grid.component.html
+++ b/src/app/alphabet-grid/alphabet-grid.component.html
@@ -1,7 +1,10 @@
 <div class="flex justify-center items-start my-5">
   <div class="p-4 w-full max-w-screen-lg">
     <div class="grid mb-10">
-      <app-word word="alfabeto" class="text-5xl"></app-word>
+      <app-word
+        [word]="currentInput ? currentInput : placeholder"
+        class="text-5xl"
+      ></app-word>
     </div>
     <div class="grid grid-cols-4 gap-5 md:grid-cols-5 lg:grid-cols-6 mt-4">
       @for (letter of alphabet; track $index) {
@@ -11,6 +14,7 @@
         [class.bg-gray-100]="selectedLetter !== letter"
         [class.bg-blue-600]="selectedLetter === letter"
         [class.text-white]="selectedLetter === letter"
+        [class.font-bold]="selectedLetter === letter"
       >
         {{ letter }}
       </button>

--- a/src/app/alphabet-grid/alphabet-grid.component.html
+++ b/src/app/alphabet-grid/alphabet-grid.component.html
@@ -1,10 +1,13 @@
 <div class="flex justify-center items-start my-5">
   <div class="p-4 w-full max-w-screen-lg">
     <div class="grid mb-10">
-      <app-word
-        [word]="currentInput ? currentInput : placeholder"
-        class="text-5xl"
-      ></app-word>
+      <div class="flex justify-between w-100 items-center">
+        <app-word
+          [word]="currentInput ? currentInput : placeholder"
+          class="text-5xl"
+        ></app-word>
+        @if (currentInput) {<button class="text-2xl" (click)="onEraseWord()">❌</button>}
+      </div>
     </div>
     <div class="grid grid-cols-4 gap-5 md:grid-cols-5 lg:grid-cols-6 mt-4">
       @for (letter of alphabet; track $index) {

--- a/src/app/alphabet-grid/alphabet-grid.component.ts
+++ b/src/app/alphabet-grid/alphabet-grid.component.ts
@@ -20,6 +20,7 @@ export class AlphabetGridComponent {
     }
     const utterance = new SpeechSynthesisUtterance(textToSpeak);
     utterance.lang = 'es-US'
+    window.speechSynthesis.cancel();
     window.speechSynthesis.speak(utterance);
   }
 }

--- a/src/app/alphabet-grid/alphabet-grid.component.ts
+++ b/src/app/alphabet-grid/alphabet-grid.component.ts
@@ -11,9 +11,12 @@ import { WordComponent } from "../shared/word/word.component";
 export class AlphabetGridComponent {
   alphabet = alphabet;
   selectedLetter: string | null = null;
+  currentInput = '';
+  placeholder = 'alfabeto'
 
   onLetterClick(letter: string) {
     this.selectedLetter = letter;
+    this.currentInput += letter;
     let textToSpeak = letter;
     if (letter === 'y') {
       textToSpeak = "i griega"

--- a/src/app/alphabet-grid/alphabet-grid.component.ts
+++ b/src/app/alphabet-grid/alphabet-grid.component.ts
@@ -1,29 +1,33 @@
 import { Component } from '@angular/core';
 import { alphabet } from '../alphabet';
-import { WordComponent } from "../shared/word/word.component";
+import { WordComponent } from '../shared/word/word.component';
 
 @Component({
   selector: 'app-alphabet-grid',
   imports: [WordComponent],
   templateUrl: './alphabet-grid.component.html',
-  styleUrl: './alphabet-grid.component.css'
+  styleUrl: './alphabet-grid.component.css',
 })
 export class AlphabetGridComponent {
   alphabet = alphabet;
   selectedLetter: string | null = null;
   currentInput = '';
-  placeholder = 'alfabeto'
+  placeholder = 'alfabeto';
 
   onLetterClick(letter: string) {
     this.selectedLetter = letter;
     this.currentInput += letter;
     let textToSpeak = letter;
     if (letter === 'y') {
-      textToSpeak = "i griega"
+      textToSpeak = 'i griega';
     }
     const utterance = new SpeechSynthesisUtterance(textToSpeak);
-    utterance.lang = 'es-US'
+    utterance.lang = 'es-US';
     window.speechSynthesis.cancel();
     window.speechSynthesis.speak(utterance);
+  }
+
+  onEraseWord() {
+    this.currentInput = '';
   }
 }

--- a/src/app/shared/word/word.component.ts
+++ b/src/app/shared/word/word.component.ts
@@ -13,6 +13,7 @@ export class WordComponent {
     this.isHighlighted = true;
     const utterance = new SpeechSynthesisUtterance(this.word);
     utterance.lang = 'es-US';
+    window.speechSynthesis.cancel();
     window.speechSynthesis.speak(utterance);
     utterance.onend = () => {
       this.isHighlighted = false;


### PR DESCRIPTION
Resolves #7 
This PR introduces a new word building feature to the application.

Prior, the application only displayed "alfabeto" above the alphabet. Now, when the user clicks on a letter, that letter replaces the "alfabeto" header. As the user selects more letters, they are able to see those letters added to the header.

Tapping on the header makes the device's speech synthesis utter the word.

The user can reset the header by click on the cross mark emoji button.

# Screenshot
![image](https://github.com/user-attachments/assets/cb4cb9b6-7dee-46cf-ac01-ee0f277935e3)
