### PR TITLE
fix: User is Routed to Wordlist

### DIFF
--- a/src/app/alphabet-grid/alphabet-grid.component.html
+++ b/src/app/alphabet-grid/alphabet-grid.component.html
@@ -15,13 +15,16 @@
       @for (letter of alphabet; track $index) {
       <button
         (mousedown)="startPressTimer(letter)"
+        (touchstart)="startPressTimer(letter)"
         (mouseup)="endPressTimer()"
+        (touchend)="endPressTimer()"
         class="p-4 rounded text-4xl"
         (click)="onLetterClick(letter)"
         [class.bg-gray-100]="selectedLetter !== letter"
         [class.bg-blue-600]="selectedLetter === letter"
         [class.text-white]="selectedLetter === letter"
         [class.font-bold]="selectedLetter === letter"
+        (contextmenu)="$event.preventDefault()"
       >
         {{ letter }}
       </button>


### PR DESCRIPTION
This PR fixes my initial oversight in routing the user to word list using the mousedown and mouseup events which do not function as expected on all mobile devices.

To get the routing working on mobile devices, I used touchstart and touchend to trigger relevant start/end press timers.