### PR TITLE
feat: Voice Input

### DIFF
--- a/src/app/alphabet-grid/alphabet-grid.component.html
+++ b/src/app/alphabet-grid/alphabet-grid.component.html
@@ -1,15 +1,28 @@
 <div class="flex justify-center items-start">
   <div class="p-4 w-full max-w-screen-lg">
-    <button
-      (click)="navigateToGame()"
-      [class.bg-blue-700]="isHighlighted"
-      [class.text-white]="isHighlighted"
-      [class.text-blue-700]="!isHighlighted"
-      [class.hover:bg-blue-200]="!isHighlighted"
-      class="font-bold py-2 px-4 rounded mb-5 flex items-center gap-2"
-    >
-      🎯 Juego de Deletreo
-    </button>
+    <div class="flex">
+      <button
+        (click)="navigateToGame()"
+        [class.bg-blue-700]="isGameHighlighted"
+        [class.text-white]="isGameHighlighted"
+        [class.text-blue-700]="!isGameHighlighted"
+        [class.hover:bg-blue-200]="!isGameHighlighted"
+        class="font-bold py-2 px-4 rounded mb-5 flex items-center gap-2"
+      >
+        🎯 Juego de Deletreo
+      </button>
+      <button
+        (click)="navigateToVoiceInput()"
+        [class.bg-blue-700]="isVoiceInputHighlighted"
+        [class.text-white]="isVoiceInputHighlighted"
+        [class.text-blue-700]="!isVoiceInputHighlighted"
+        [class.hover:bg-blue-200]="!isVoiceInputHighlighted"
+        class="font-bold py-2 px-4 rounded mb-5 flex items-center gap-2"
+      >
+        🎙️ Entrada de Voz
+      </button>
+    </div>
+
     <div class="grid mb-10">
       <div class="flex justify-between w-100 items-center">
         <app-word

--- a/src/app/alphabet-grid/alphabet-grid.component.ts
+++ b/src/app/alphabet-grid/alphabet-grid.component.ts
@@ -15,7 +15,9 @@ export class AlphabetGridComponent {
   currentInput = '';
   placeholder = 'alfabeto';
   pressTimer: any;
-  isHighlighted = false;
+  isGameHighlighted = false;
+  isVoiceInputHighlighted = false;
+
   constructor(private router: Router) {}
 
   onLetterClick(letter: string) {
@@ -46,16 +48,30 @@ export class AlphabetGridComponent {
   }
 
   navigateToGame() {
-    if (!this.isHighlighted) {
-      this.isHighlighted = true;
+    if (!this.isGameHighlighted) {
+      this.isGameHighlighted = true;
       const utterance = new SpeechSynthesisUtterance('Juego de deletreo');
       utterance.lang = 'es-US';
       window.speechSynthesis.speak(utterance);
       setTimeout(() => {
-        this.isHighlighted = false;
+        this.isGameHighlighted = false;
       }, 5000);
     } else {
       this.router.navigate(['/game']);
+    }
+  }
+
+  navigateToVoiceInput() {
+    if (!this.isVoiceInputHighlighted) {
+      this.isVoiceInputHighlighted = true;
+      const utterance = new SpeechSynthesisUtterance('Entrada de Voz');
+      utterance.lang = 'es-US';
+      window.speechSynthesis.speak(utterance);
+      setTimeout(() => {
+        this.isVoiceInputHighlighted = false;
+      }, 5000);
+    } else {
+      this.router.navigate(['/voice']);
     }
   }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,10 +3,12 @@ import { OnboardingComponent } from './onboarding/onboarding.component';
 import { AlphabetGridComponent } from './alphabet-grid/alphabet-grid.component';
 import { WordsListComponent } from './words-list/words-list.component';
 import { SpellingGameComponent } from './spelling-game/spelling-game.component';
+import { VoiceComponent } from './voice/voice.component';
 
 export const routes: Routes = [
   { path: 'onboarding', component: OnboardingComponent },
   { path: '', component: AlphabetGridComponent },
   { path: 'words/:letter', component: WordsListComponent },
   { path: 'game', component: SpellingGameComponent },
+  { path: 'voice', component: VoiceComponent },
 ];

--- a/src/app/spelling-game/spelling-game.component.ts
+++ b/src/app/spelling-game/spelling-game.component.ts
@@ -26,7 +26,6 @@ export class SpellingGameComponent implements OnInit {
     }
 
     this.availableLetters = Array.from(letters).sort(() => Math.random() - 0.5);
-    console.log(this.availableLetters, this.targetEmoji, this.targetWord);
   }
 
   async loadNewWord() {

--- a/src/app/voice/voice.component.html
+++ b/src/app/voice/voice.component.html
@@ -1,0 +1,1 @@
+<p>voice works!</p>

--- a/src/app/voice/voice.component.html
+++ b/src/app/voice/voice.component.html
@@ -1,1 +1,25 @@
-<p>voice works!</p>
+<div
+  class="flex flex-col items-center justify-start h-screen p-8 pt-16 max-w-2xl mx-auto"
+>
+  <h1 class="text-3xl text-center mb-8">Voice Input</h1>
+  <button
+    class="p-4 bg-gray-200 rounded-full text-4xl my-4"
+    (click)="isListening ? stopListening() : startListening()"
+  >
+    @if(!isListening) {<span>🎙️</span>} @else if (isListening) { <span>⏹️</span>}
+  </button>
+  <textarea
+    rows="10"
+    class="w-full p-4 border border-gray-300 rounded my-4"
+    [value]="transcribedText"
+    readonly
+    placeholder="Your transcribed text will appear here"
+  >
+  </textarea>
+  <div class="flex justify-center gap-4">
+    <button class="p-2 bg-gray-200 rounded" (click)="copyToClipboard()">
+      Copy
+    </button>
+    <button class="p-2 bg-gray-200 rounded" (click)="clearText()">Clear</button>
+  </div>
+</div>

--- a/src/app/voice/voice.component.html
+++ b/src/app/voice/voice.component.html
@@ -1,25 +1,30 @@
-<div
-  class="flex flex-col items-center justify-start h-screen p-8 pt-16 max-w-2xl mx-auto"
->
-  <h1 class="text-3xl text-center mb-8">Voice Input</h1>
-  <button
-    class="p-4 bg-gray-200 rounded-full text-4xl my-4"
-    (click)="isListening ? stopListening() : startListening()"
-  >
-    @if(!isListening) {<span>🎙️</span>} @else if (isListening) { <span>⏹️</span>}
-  </button>
-  <textarea
-    rows="10"
-    class="w-full p-4 border border-gray-300 rounded my-4"
-    [value]="transcribedText"
-    readonly
-    placeholder="Your transcribed text will appear here"
-  >
-  </textarea>
-  <div class="flex justify-center gap-4">
-    <button class="p-2 bg-gray-200 rounded" (click)="copyToClipboard()">
-      Copy
-    </button>
-    <button class="p-2 bg-gray-200 rounded" (click)="clearText()">Clear</button>
+<div class="flex justify-center items-start my-5">
+  <div class="p-4 w-full max-w-screen-lg">
+    <a href="/" class="text-4xl me-4">⬅️</a>
+    <div class="flex justify-start gap-2 flex-wrap">
+      <button
+        class="bg-gray-200 rounded-full text-4xl p-4 mx-auto my-6"
+        (click)="isListening ? stopListening() : startListening()"
+      >
+        @if(!isListening) {<span>🎙️</span>} @else if (isListening)
+        {<span>⏹️</span>}
+      </button>
+
+      <textarea
+        rows="10"
+        class="w-full p-4 border border-gray-300 rounded my-4"
+        [value]="transcribedText"
+        readonly
+      >
+      </textarea>
+      <div class="flex justify-center gap-4">
+        <button class="p-2 bg-gray-200 rounded" (click)="copyToClipboard()">
+          📋
+        </button>
+        <button class="p-2 bg-gray-200 rounded" (click)="clearText()">
+          ❌
+        </button>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/voice/voice.component.spec.ts
+++ b/src/app/voice/voice.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VoiceComponent } from './voice.component';
+
+describe('VoiceComponent', () => {
+  let component: VoiceComponent;
+  let fixture: ComponentFixture<VoiceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VoiceComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VoiceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/voice/voice.component.ts
+++ b/src/app/voice/voice.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-voice',
+  imports: [],
+  templateUrl: './voice.component.html',
+  styleUrl: './voice.component.css'
+})
+export class VoiceComponent {
+
+}

--- a/src/app/voice/voice.component.ts
+++ b/src/app/voice/voice.component.ts
@@ -1,11 +1,77 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy } from '@angular/core';
+declare global {
+  interface Window {
+    SpeechRecognition: any;
+    webkitSpeechRecognition: any;
+  }
+}
 
 @Component({
   selector: 'app-voice',
   imports: [],
   templateUrl: './voice.component.html',
-  styleUrl: './voice.component.css'
+  styleUrl: './voice.component.css',
 })
-export class VoiceComponent {
+export class VoiceComponent implements OnDestroy {
+  isListening = false;
+  transcribedText = '';
+  speechRecognition: any | null = null;
 
+  constructor(private cdr: ChangeDetectorRef) {
+    if ('SpeechRecognition' in window || 'webkitSpeechRecognition' in window) {
+      this.speechRecognition = new ((window as any).SpeechRecognition ||
+        (window as any).webkitSpeechRecognition)();
+      this.speechRecognition.lang = 'es-ES';
+      this.speechRecognition.continuous = true; // Enable continuous transcription
+      this.speechRecognition.interimResults = true; // Show interim results
+      this.speechRecognition.onresult = (event: any) => {
+        let transcript = '';
+        for (let i = event.resultIndex; i < event.results.length; ++i) {
+          transcript += event.results[i][0].transcript;
+        }
+        this.transcribedText = transcript;
+        this.cdr.detectChanges(); // Trigger change detection after updating the transcribedText
+      };
+
+      this.speechRecognition.onstart = () => {};
+      this.speechRecognition.onend = () => {
+        this.isListening = false;
+      };
+      this.speechRecognition.onerror = (error: any) => {
+        this.isListening = false;
+        console.error('Speech recognition error:', error);
+      };
+    } else {
+      console.error('Browser does not support Speech Recognition API');
+    }
+  }
+
+  startListening() {
+    if (this.speechRecognition) {
+      this.transcribedText = ''; // clear the transcribed text on start.
+      this.isListening = true;
+      this.speechRecognition.start();
+    }
+  }
+
+  stopListening() {
+    if (this.speechRecognition) {
+      this.speechRecognition.stop();
+      this.isListening = false;
+    }
+  }
+
+  clearText() {
+    this.transcribedText = '';
+  }
+
+  copyToClipboard() {
+    navigator.clipboard.writeText(this.transcribedText);
+  }
+
+  ngOnDestroy(): void {
+    if (this.speechRecognition) {
+      this.speechRecognition.abort();
+    }
+  }
 }


### PR DESCRIPTION
Resolves #15 

This PR implements a new voice input feature into the application. 

This is accomplished by creating a new route (`/voice`) which the user can navigate to from the home (alphabet-grid) component. 

When the user navigates to the voice input route, they are greeted with a screen composed of a button with a microphone emoji, and a blank textarea field underneath with two buttons underneath it.

When the user taps on the microphone button, the user's device speech recognition begins to listen to the user's voice input. The microphone is replaced with an stop icon emoji which the user can click on top stop voice input.

As soon as the user starts speaking, the textarea begins to fill with the user's speech. The user can press the two buttons underneath the textarea to copy their written words or to reset the input field.

In future work, I would like to make sure the voice input words are grammatically structured with periods and commas (#19)

# Screenshot
## Empty Input
![image](https://github.com/user-attachments/assets/402dace9-3f44-4e5a-9c5a-106fa34c03df)

## Listening
![image](https://github.com/user-attachments/assets/d5ad4356-3622-4678-9b35-e2129224caba)
